### PR TITLE
Feature/dill serialization

### DIFF
--- a/cosmoHammer/util/MpiUtil.py
+++ b/cosmoHammer/util/MpiUtil.py
@@ -3,12 +3,16 @@ import os
 from cosmoHammer import getLogger
 import time
 import dill
+import sys
 
 # If mpi4py is installed, import it.
 try:
     from mpi4py import MPI
     MPI = MPI
-    MPI.pickle.__init__(dill.dumps, dill.loads)
+
+    # for Python 3
+    if sys.version_info > (3, 0):
+        MPI.pickle.__init__(dill.dumps, dill.loads)
 except ImportError:
     MPI = None
 

--- a/cosmoHammer/util/MpiUtil.py
+++ b/cosmoHammer/util/MpiUtil.py
@@ -2,11 +2,13 @@ import itertools
 import os
 from cosmoHammer import getLogger
 import time
+import dill
 
 # If mpi4py is installed, import it.
 try:
     from mpi4py import MPI
     MPI = MPI
+    MPI.pickle.__init__(dill.dumps, dill.loads)
 except ImportError:
     MPI = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ emcee
 numpy
 mock
 pytest
+dill


### PR DESCRIPTION
Use dill for serialization in Python 3. Otherwise, the PSO module runs into error (issue https://github.com/cosmo-ethz/CosmoHammer/issues/10) when run with MPI.